### PR TITLE
Multiline descriptions

### DIFF
--- a/addon/components/types/ical-cal.js
+++ b/addon/components/types/ical-cal.js
@@ -30,6 +30,11 @@ export default Base.extend({
     if (!moment.isMoment(endTime)) {
       endTime = moment(endTime);
     }
+    if (description) {
+      description = description
+        .replace(/<br\s*\/?>/gi, '\\n')
+        .replace(/<(?:.|\n)*?>/gm, '=0D=0A');
+    }
     let start = startTime.format('YYYYMMDDTHHmmss');
     let end = endTime.format('YYYYMMDDTHHmmss');
 

--- a/addon/components/types/ical-cal.js
+++ b/addon/components/types/ical-cal.js
@@ -1,22 +1,29 @@
 import Base from '../button-base';
 import layout from '../../templates/components/types/ical-cal';
 import moment from 'moment';
-import {computed, get} from '@ember/object';
-import {dasherize} from '@ember/string';
+import { computed, get } from '@ember/object';
+import { dasherize } from '@ember/string';
 
 // Fastboot support
-const doc = document || {URL: false}
+const doc = document || { URL: false };
 
 export default Base.extend({
   layout,
   attributeBindings: ['download'],
   download: computed('event', function() {
-    let title = `${get(this, 'event.title')}-${get(this, 'startTime').format('YYYY-MM-DD')}`
-    let safe = dasherize(title)
-    return `${safe
-    }.ics`;
+    let title = `${get(this, 'event.title')}-${get(this, 'startTime').format(
+      'YYYY-MM-DD'
+    )}`;
+    let safe = dasherize(title);
+    return `${safe}.ics`;
   }),
-  generateHref({startTime = '', endTime = '', location = '', title = '', description = ''}){
+  generateHref({
+    startTime = '',
+    endTime = '',
+    location = '',
+    title = '',
+    description = ''
+  }) {
     if (!moment.isMoment(startTime)) {
       startTime = moment(startTime);
     }
@@ -27,24 +34,24 @@ export default Base.extend({
     let end = endTime.format('YYYYMMDDTHHmmss');
 
     let text = [
-          'BEGIN:VCALENDAR',
-          'VERSION:2.0',
-          'BEGIN:VTIMEZONE',
-          'TZNAME:EST',
-          'TZID:America/New_York',
-          'END:VTIMEZONE',
-          'BEGIN:VEVENT',
-          'URL:' + doc.URL,
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'BEGIN:VTIMEZONE',
+      'TZNAME:EST',
+      'TZID:America/New_York',
+      'END:VTIMEZONE',
+      'BEGIN:VEVENT',
+      'URL:' + doc.URL,
 
-          `DTSTART;TZID=America/New_York:${start}`,
-          `DTEND;TZID=America/New_York:${end}`,
-          `SUMMARY:${title}`,
-          `DESCRIPTION:${description}`,
-          `LOCATION:${location}`,
-          'END:VEVENT',
-          'END:VCALENDAR'
-        ];
+      `DTSTART;TZID=America/New_York:${start}`,
+      `DTEND;TZID=America/New_York:${end}`,
+      `SUMMARY:${title}`,
+      `DESCRIPTION;ENCODING=QUOTED-PRINTABLE:${description}`,
+      `LOCATION:${location}`,
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ];
 
-      return encodeURI(`data:text/calendar;charset=utf8,${text.join('\n')}`)
+    return encodeURI(`data:text/calendar;charset=utf8,${text.join('\n')}`);
   }
 });


### PR DESCRIPTION
Hello! 👋🏻 

I use your addon at work, and noticed that it doesn't support multiline ics descriptions yet. This PR adds that feature. The idea is based on [this article](https://www.stevefenton.co.uk/2010/11/Adding-Multiple-Lines-To-Description-In-ICalendar-Files/). In short, I'm replacing `DESCRIPTION:${description}` with `DESCRIPTION;ENCODING=QUOTED-PRINTABLE:${description}`, and subbing `=0D=0A` in for `<br />` and `\n`.

Let me know if there's any additional info you need!